### PR TITLE
Add ckan-scheming

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ For more information please see [ckanext-envvars](https://github.com/okfn/ckanex
 
 A extensão `ckanext-scheming` é usada para criar campos em datasets, organizações, recursos e grupos usando YAML ou JSON. Podemos adicionar validação dos campos.
 
+Para mais detalhes [ckanext-scheming no GitHub](https://github.com/ckan/ckanext-scheming)
+
 ## 10. CKAN_SITE_URL
 
 For convenience the CKAN_SITE_URL parameter should be set in the .env file. For development it can be set to http://localhost:5000 and non-development set to https://localhost:8443

--- a/README.md
+++ b/README.md
@@ -314,6 +314,10 @@ These parameters can be added to the `.env` file
 
 For more information please see [ckanext-envvars](https://github.com/okfn/ckanext-envvars)
 
+## ckanext-scheming
+
+A extensão `ckanext-scheming` é usada para criar campos em datasets, organizações, recursos e grupos usando YAML ou JSON. Podemos adicionar validação dos campos.
+
 ## 10. CKAN_SITE_URL
 
 For convenience the CKAN_SITE_URL parameter should be set in the .env file. For development it can be set to http://localhost:5000 and non-development set to https://localhost:8443

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -10,6 +10,13 @@ COPY --chown=ckan-sys:ckan-sys docker-entrypoint.d/* /docker-entrypoint.d/
 # runtime mounted ones)
 COPY --chown=ckan-sys:ckan-sys patches ${APP_DIR}/patches
 
+USER root
+
+### Scheming ###
+RUN pip3 install -e 'git+https://github.com/ckan/ckanext-scheming.git@master#egg=ckanext-scheming'
+
+COPY ./ckan_dataset_schema.yaml ${APP_DIR}/src/ckanext-scheming/ckanext/scheming
+
 USER ckan
 
 RUN for d in $APP_DIR/patches/*; do \

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -12,7 +12,7 @@ FROM ckan/ckan-dev:2.11
 # For instance:
 #
 ### XLoader ###
-#RUN pip3 install -e 'git+https://github.com/ckan/ckanext-xloader.git@master#egg=ckanext-xloader' && \ 
+#RUN pip3 install -e 'git+https://github.com/ckan/ckanext-xloader.git@master#egg=ckanext-xloader' && \
 #    pip3 install -r ${APP_DIR}/src/ckanext-xloader/requirements.txt && \
 #    pip3 install -U requests[security]
 
@@ -48,9 +48,9 @@ COPY --chown=ckan-sys:ckan-sys patches ${APP_DIR}/patches
 USER ckan
 
 RUN for d in $APP_DIR/patches/*; do \
-        if [ -d $d ]; then \
-            for f in `ls $d/*.patch | sort -g`; do \
-                cd $SRC_DIR/`basename "$d"` && echo "$0: Applying patch $f to $SRC_DIR/`basename $d`"; patch -p1 < "$f" ; \
-            done ; \
-        fi ; \
+    if [ -d $d ]; then \
+    for f in `ls $d/*.patch | sort -g`; do \
+    cd $SRC_DIR/`basename "$d"` && echo "$0: Applying patch $f to $SRC_DIR/`basename $d`"; patch -p1 < "$f" ; \
+    done ; \
+    fi ; \
     done

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -48,9 +48,9 @@ COPY --chown=ckan-sys:ckan-sys patches ${APP_DIR}/patches
 USER ckan
 
 RUN for d in $APP_DIR/patches/*; do \
-    if [ -d $d ]; then \
-    for f in `ls $d/*.patch | sort -g`; do \
-    cd $SRC_DIR/`basename "$d"` && echo "$0: Applying patch $f to $SRC_DIR/`basename $d`"; patch -p1 < "$f" ; \
-    done ; \
-    fi ; \
+        if [ -d $d ]; then \
+            for f in `ls $d/*.patch | sort -g`; do \
+                cd $SRC_DIR/`basename "$d"` && echo "$0: Applying patch $f to $SRC_DIR/`basename $d`"; patch -p1 < "$f" ; \
+            done ; \
+        fi ; \
     done

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -22,7 +22,9 @@ FROM ckan/ckan-dev:2.11.0
 # will also require gather_consumer and fetch_consumer processes running (please see https://github.com/ckan/ckanext-harvest)
 
 ### Scheming ###
-#RUN  pip3 install -e 'git+https://github.com/ckan/ckanext-scheming.git@master#egg=ckanext-scheming'
+RUN  pip3 install -e 'git+https://github.com/ckan/ckanext-scheming.git@master#egg=ckanext-scheming'
+
+COPY ./ckan_dataset_schema.yaml ${APP_DIR}/src/ckanext-scheming/ckanext/scheming
 
 ### Pages ###
 #RUN  pip3 install -e git+https://github.com/ckan/ckanext-pages.git#egg=ckanext-pages

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -12,7 +12,7 @@ FROM ckan/ckan-dev:2.11
 # For instance:
 #
 ### XLoader ###
-#RUN pip3 install -e 'git+https://github.com/ckan/ckanext-xloader.git@master#egg=ckanext-xloader' && \
+#RUN pip3 install -e 'git+https://github.com/ckan/ckanext-xloader.git@master#egg=ckanext-xloader' && \ 
 #    pip3 install -r ${APP_DIR}/src/ckanext-xloader/requirements.txt && \
 #    pip3 install -U requests[security]
 

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -21,8 +21,10 @@ FROM ckan/ckan-dev:2.11
 #    pip3 install -r ${APP_DIR}/src/ckanext-harvest/pip-requirements.txt
 # will also require gather_consumer and fetch_consumer processes running (please see https://github.com/ckan/ckanext-harvest)
 
+USER root
+
 ### Scheming ###
-RUN  pip3 install -e 'git+https://github.com/ckan/ckanext-scheming.git@master#egg=ckanext-scheming'
+RUN pip3 install -e 'git+https://github.com/ckan/ckanext-scheming.git@master#egg=ckanext-scheming'
 
 COPY ./ckan_dataset_schema.yaml ${APP_DIR}/src/ckanext-scheming/ckanext/scheming
 

--- a/ckan/ckan_dataset_schema.yaml
+++ b/ckan/ckan_dataset_schema.yaml
@@ -11,15 +11,6 @@ dataset_fields:
   preset: title
   form_placeholder: eg. A descriptive title
 
-- field_name: category
-  preset: select
-  label: Category
-  choices:
-  - value: bactrian
-    label: Bactrian Camel
-  - value: hybrid
-    label: Hybrid Camel
-
 - field_name: name
   label: URL
   preset: dataset_slug
@@ -82,7 +73,7 @@ dataset_fields:
 - field_name: spatial_coverage
   label: Cobertura Espacial
   form_placeholder: Brasil, Estados, Município
-  validators: ignore_missing
+  validators: not_empty
   required: true
 
 resource_fields:

--- a/ckan/ckan_dataset_schema.yaml
+++ b/ckan/ckan_dataset_schema.yaml
@@ -79,6 +79,11 @@ dataset_fields:
   display_snippet: email.html
   display_email_name_field: maintainer
 
+- field_name: spatial_coverage
+  label: Cobertura Espacial
+  form_placeholder: Brasil, Estados, Município
+  validators: ignore_missing
+  required: true
 
 resource_fields:
 

--- a/ckan/ckan_dataset_schema.yaml
+++ b/ckan/ckan_dataset_schema.yaml
@@ -3,94 +3,95 @@ dataset_type: dataset
 about: A reimplementation of the default CKAN dataset schema
 about_url: http://github.com/ckan/ckanext-scheming
 
-
 dataset_fields:
+  - field_name: title
+    label: Title
+    preset: title
+    form_placeholder: eg. A descriptive title
 
-- field_name: title
-  label: Title
-  preset: title
-  form_placeholder: eg. A descriptive title
+  - field_name: name
+    label: URL
+    preset: dataset_slug
+    form_placeholder: eg. my-dataset
 
-- field_name: name
-  label: URL
-  preset: dataset_slug
-  form_placeholder: eg. my-dataset
+  - field_name: notes
+    label: Description
+    form_snippet: markdown.html
+    form_placeholder: eg. Some useful notes about the data
 
-- field_name: notes
-  label: Description
-  form_snippet: markdown.html
-  form_placeholder: eg. Some useful notes about the data
+  - field_name: tag_string
+    label: Tags
+    preset: tag_string_autocomplete
+    form_placeholder: eg. economy, mental health, government
 
-- field_name: tag_string
-  label: Tags
-  preset: tag_string_autocomplete
-  form_placeholder: eg. economy, mental health, government
+  - field_name: license_id
+    label: License
+    form_snippet: license.html
+    help_text: License definitions and additional information can be found at http://opendefinition.org/
 
-- field_name: license_id
-  label: License
-  form_snippet: license.html
-  help_text: License definitions and additional information can be found at http://opendefinition.org/
+  - field_name: owner_org
+    label: Organization
+    preset: dataset_organization
 
-- field_name: owner_org
-  label: Organization
-  preset: dataset_organization
+  - field_name: url
+    label: Source
+    form_placeholder: http://example.com/dataset.json
+    display_property: foaf:homepage
+    display_snippet: link.html
 
-- field_name: url
-  label: Source
-  form_placeholder: http://example.com/dataset.json
-  display_property: foaf:homepage
-  display_snippet: link.html
+  - field_name: version
+    label: Version
+    validators: ignore_missing unicode_safe package_version_validator
+    form_placeholder: "1.0"
 
-- field_name: version
-  label: Version
-  validators: ignore_missing unicode_safe package_version_validator
-  form_placeholder: '1.0'
+  - field_name: author
+    label: Author
+    form_placeholder: Joe Bloggs
+    display_property: dc:creator
 
-- field_name: author
-  label: Author
-  form_placeholder: Joe Bloggs
-  display_property: dc:creator
+  - field_name: author_email
+    label: Author Email
+    form_placeholder: joe@example.com
+    display_property: dc:creator
+    display_snippet: email.html
+    display_email_name_field: author
 
-- field_name: author_email
-  label: Author Email
-  form_placeholder: joe@example.com
-  display_property: dc:creator
-  display_snippet: email.html
-  display_email_name_field: author
+  - field_name: maintainer
+    label: Maintainer
+    form_placeholder: Joe Bloggs
+    display_property: dc:contributor
 
-- field_name: maintainer
-  label: Maintainer
-  form_placeholder: Joe Bloggs
-  display_property: dc:contributor
+  - field_name: maintainer_email
+    label: Maintainer Email
+    form_placeholder: joe@example.com
+    display_property: dc:contributor
+    display_snippet: email.html
+    display_email_name_field: maintainer
 
-- field_name: maintainer_email
-  label: Maintainer Email
-  form_placeholder: joe@example.com
-  display_property: dc:contributor
-  display_snippet: email.html
-  display_email_name_field: maintainer
-
-- field_name: spatial_coverage
-  label: Cobertura Espacial
-  form_placeholder: Brasil, Estados, Município
-  validators: not_empty
-  required: true
+  - field_name: spatial_coverage
+    label: Cobertura Espacial
+    form_placeholder: Brasil, Estados, Município
+    validators: not_empty
+    required: true
 
 resource_fields:
+  - field_name: url
+    label: URL
+    preset: resource_url_upload
 
-- field_name: url
-  label: URL
-  preset: resource_url_upload
+  - field_name: name
+    label: Name
+    form_placeholder: eg. January 2011 Gold Prices
 
-- field_name: name
-  label: Name
-  form_placeholder: eg. January 2011 Gold Prices
+  - field_name: description
+    label: Description
+    form_snippet: markdown.html
+    form_placeholder: Some useful notes about the data
 
-- field_name: description
-  label: Description
-  form_snippet: markdown.html
-  form_placeholder: Some useful notes about the data
+  - field_name: update_freq
+    label: Frequência de atualização dos dados
+    form_placeholder: A cada 6 meses
 
-- field_name: format
-  label: Format
-  preset: resource_format_autocomplete
+  - field_name: format
+    label: Format
+    preset: resource_format_autocomplete

--- a/ckan/ckan_dataset_schema.yaml
+++ b/ckan/ckan_dataset_schema.yaml
@@ -22,12 +22,8 @@ dataset_fields:
   - field_name: tag_string
     label: Tags
     preset: tag_string_autocomplete
-    form_placeholder: eg. economy, mental health, government
-
-  - field_name: license_id
-    label: License
-    form_snippet: license.html
-    help_text: License definitions and additional information can be found at http://opendefinition.org/
+    form_placeholder: eg. imovel, terreno, ocupacao
+    required: true
 
   - field_name: owner_org
     label: Organization
@@ -41,8 +37,9 @@ dataset_fields:
 
   - field_name: version
     label: Version
-    validators: ignore_missing unicode_safe package_version_validator
-    form_placeholder: "1.0"
+    validators: not_empty is_positive_integer
+    form_placeholder: 1, 2, 3
+    required: true
 
   - field_name: author
     label: Author
@@ -70,7 +67,7 @@ dataset_fields:
 
   - field_name: spatial_coverage
     label: Cobertura Espacial
-    form_placeholder: Brasil, Estados, Município
+    form_placeholder: Centro, Zona Sul, Zona Oeste, Zona Leste
     validators: not_empty
     required: true
 

--- a/ckan/ckan_dataset_schema.yaml
+++ b/ckan/ckan_dataset_schema.yaml
@@ -1,0 +1,100 @@
+scheming_version: 2
+dataset_type: dataset
+about: A reimplementation of the default CKAN dataset schema
+about_url: http://github.com/ckan/ckanext-scheming
+
+
+dataset_fields:
+
+- field_name: title
+  label: Title
+  preset: title
+  form_placeholder: eg. A descriptive title
+
+- field_name: category
+  preset: select
+  label: Category
+  choices:
+  - value: bactrian
+    label: Bactrian Camel
+  - value: hybrid
+    label: Hybrid Camel
+
+- field_name: name
+  label: URL
+  preset: dataset_slug
+  form_placeholder: eg. my-dataset
+
+- field_name: notes
+  label: Description
+  form_snippet: markdown.html
+  form_placeholder: eg. Some useful notes about the data
+
+- field_name: tag_string
+  label: Tags
+  preset: tag_string_autocomplete
+  form_placeholder: eg. economy, mental health, government
+
+- field_name: license_id
+  label: License
+  form_snippet: license.html
+  help_text: License definitions and additional information can be found at http://opendefinition.org/
+
+- field_name: owner_org
+  label: Organization
+  preset: dataset_organization
+
+- field_name: url
+  label: Source
+  form_placeholder: http://example.com/dataset.json
+  display_property: foaf:homepage
+  display_snippet: link.html
+
+- field_name: version
+  label: Version
+  validators: ignore_missing unicode_safe package_version_validator
+  form_placeholder: '1.0'
+
+- field_name: author
+  label: Author
+  form_placeholder: Joe Bloggs
+  display_property: dc:creator
+
+- field_name: author_email
+  label: Author Email
+  form_placeholder: joe@example.com
+  display_property: dc:creator
+  display_snippet: email.html
+  display_email_name_field: author
+
+- field_name: maintainer
+  label: Maintainer
+  form_placeholder: Joe Bloggs
+  display_property: dc:contributor
+
+- field_name: maintainer_email
+  label: Maintainer Email
+  form_placeholder: joe@example.com
+  display_property: dc:contributor
+  display_snippet: email.html
+  display_email_name_field: maintainer
+
+
+resource_fields:
+
+- field_name: url
+  label: URL
+  preset: resource_url_upload
+
+- field_name: name
+  label: Name
+  form_placeholder: eg. January 2011 Gold Prices
+
+- field_name: description
+  label: Description
+  form_snippet: markdown.html
+  form_placeholder: Some useful notes about the data
+
+- field_name: format
+  label: Format
+  preset: resource_format_autocomplete

--- a/ckan/docker-entrypoint.d/02_setup_scheming.sh
+++ b/ckan/docker-entrypoint.d/02_setup_scheming.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+ckan config-tool $CKAN_INI "scheming.dataset_schemas = ckanext.scheming:ckan_dataset_schema.yaml"
+ckan config-tool $CKAN_INI "scheming.presets = ckanext.scheming:presets.json"


### PR DESCRIPTION
# Descrição

Esse PR adiciona a extensão ckan-scheming para customizar os campos de metadados de datasets, recursos.

# Detalhes

- O arquivo `ckan/ckan_dataset_schema.yaml` define os campos.
  - Podemos deletar e adicionar campos para datasets e recursos.
  - Validações podem ser adicionadas, exemplo: `not_empty`, `is_positive_integer` entre outros. Aqui uma lista dos [validators](https://docs.ckan.org/en/latest/extensions/validators.html)
- Os campos estão disponível da API