### PR TITLE
Revert #194 from upstream

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,7 +5,7 @@ volumes:
   pip_cache:
   site_packages:
   local_bin:
-  home_dir:
+  vscode_server:
 
 services:
 
@@ -29,7 +29,7 @@ services:
       - pip_cache:/root/.cache/pip
       - site_packages:/usr/local/lib/python3.10/site-packages
       - local_bin:/usr/local/bin
-      - home_dir:/srv/app/
+      - vscode_server:/root/.vscode-server
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:5000"]


### PR DESCRIPTION
Reverte alteração de https://github.com/ckan/ckan-docker/pull/194

A mudança tem uma implicação para o ambiente de dev: Ela cria um volume `home_dir` e não e possível que alterações durante a build da imagem seja refletida. Eu preciso deletar o volume.

Exemplo: Ao fazer alterações em https://github.com/sepep-pmsp/ckan-codata/blob/master/ckan/ckan_dataset_schema.yaml eu preciso deletar o volume